### PR TITLE
create new test case on saving entry row

### DIFF
--- a/src/components/DetailPane.tsx
+++ b/src/components/DetailPane.tsx
@@ -8,43 +8,54 @@ type DetailPaneProps = {
   selectedTestCase: TestCaseObject;
   updateSelectedTestCase: (testCase: TestCaseObject) => void;
   updateTestCaseByKey: (testCase: TestCaseObject) => void;
+  addTestCase: (testCase: TestCaseObject) => void;
 }
 
-const DetailPane = ({ selectedTestCase, updateSelectedTestCase, updateTestCaseByKey }: DetailPaneProps ) => {
-    if (selectedTestCase) {
-      return (
-        <div className="Detail-pane">
-          <div className="Debug-key">{selectedTestCase.key}</div>
-          <div className="Detail-pane-header">
-            <h1>{selectedTestCase.summary}</h1>
-          </div>
-          <div className="Detail-pane-body">
-          <Description
-            selectedTestCase={selectedTestCase}
-            updateSelectedTestCase={updateSelectedTestCase}
-          />
-          <StepList
-            selectedTestCase={selectedTestCase}
-            updateSelectedTestCase={updateSelectedTestCase}
-          />
-          <TagList
-            selectedTestCase={selectedTestCase}
-            updateSelectedTestCase={updateSelectedTestCase}
-          />
-          </div>
-          <div className="Detail-pane-footer">
-            <button 
-              className="Save-details"
-              disabled={selectedTestCase.disabled}
-              onClick={() => updateTestCaseByKey(selectedTestCase)}
-            >Save</button>
-          </div>
-        </div>
-      );
+const DetailPane = ({ selectedTestCase, updateSelectedTestCase, updateTestCaseByKey, addTestCase }: DetailPaneProps ) => {
+  
+  const save = (testCase: TestCaseObject) => {
+    if (testCase.key !== 'blank') {
+      updateTestCaseByKey(testCase)
     }
-    else {
-      return null;
+    else if (testCase.key === 'blank' && testCase.summary !== '') {
+      addTestCase(testCase)
     }
   }
+  
+  if (selectedTestCase) {
+    return (
+      <div className="Detail-pane">
+        <div className="Debug-key">{selectedTestCase.key}</div>
+        <div className="Detail-pane-header">
+          <h1>{selectedTestCase.summary}</h1>
+        </div>
+        <div className="Detail-pane-body">
+        <Description
+          selectedTestCase={selectedTestCase}
+          updateSelectedTestCase={updateSelectedTestCase}
+        />
+        <StepList
+          selectedTestCase={selectedTestCase}
+          updateSelectedTestCase={updateSelectedTestCase}
+        />
+        <TagList
+          selectedTestCase={selectedTestCase}
+          updateSelectedTestCase={updateSelectedTestCase}
+        />
+        </div>
+        <div className="Detail-pane-footer">
+          <button 
+            className="Save-details"
+            disabled={selectedTestCase.disabled}
+            onClick={() => save(selectedTestCase)}
+          >Save</button>
+        </div>
+      </div>
+    );
+  }
+  else {
+    return null;
+  }
+}
 
 export default DetailPane;

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -112,6 +112,7 @@ const MainContainer = () => {
         selectedTestCase={selectedTestCase}
         updateSelectedTestCase={updateSelectedTestCase}
         updateTestCaseByKey={updateTestCaseByKey}
+        addTestCase={addTestCase}
       />
       </div>
     </div>


### PR DESCRIPTION
#### Old behaviour
'Save' was not creating a new test case if you were editing the entry row

#### New behaviour
'Save' now creates a new test case in the same way as using Enter or Tab when using the entry row

The focus is removed from the entry row, so you need to click back on the entry row to create a new test case (may be improved in a future PR)